### PR TITLE
Added glue go code

### DIFF
--- a/c_api.h
+++ b/c_api.h
@@ -75,3 +75,8 @@ extern void add_summary(char *measurment,
         struct tag *tags, int tags_size,
         struct field *fields, int fields_size,
         int64_t unix_sec, int64_t unix_nsec);
+
+extern void add_histogram(char *measurment,
+        struct tag *tags, int tags_size,
+        struct field *fields, int fields_size,
+        int64_t unix_sec, int64_t unix_nsec);

--- a/c_api.h
+++ b/c_api.h
@@ -65,3 +65,8 @@ extern void add_gauge(char *measurment,
         struct tag *tags, int tags_size,
         struct field *fields, int fields_size,
         int64_t unix_sec, int64_t unix_nsec);
+
+extern void add_counter(char *measurment,
+        struct tag *tags, int tags_size,
+        struct field *fields, int fields_size,
+        int64_t unix_sec, int64_t unix_nsec);

--- a/c_api.h
+++ b/c_api.h
@@ -22,14 +22,23 @@
 //
 // Software written by Preston Carpenter <pcarpenter@starry.com>
 #include <assert.h>
+#include <stdbool.h>
 #include <stdint.h>
 
 struct go_value {
     enum {
-        TYPE_INT
+        TYPE_INT,
+        TYPE_UINT,
+        TYPE_FLOAT,
+        TYPE_BOOL,
+        TYPE_STRING,
     } type_;
     union {
-        int int_;
+        int64_t int_;
+        uint64_t uint_;
+        double double_;
+        bool bool_;
+        char *string_;
     } value;
 };
 
@@ -42,9 +51,29 @@ struct field {
     struct go_value value;
 };
 
-static int get_go_value_int(struct go_value value) {
-    assert(value.type_ == TYPE_INT);
-    return value.value.int_;
+static int64_t get_go_value_int(struct go_value go_value) {
+    assert(go_value.type_ == TYPE_INT);
+    return go_value.value.int_;
+}
+
+static uint64_t get_go_value_uint(struct go_value go_value) {
+    assert(go_value.type_ == TYPE_UINT);
+    return go_value.value.uint_;
+}
+
+static double get_go_value_double(struct go_value go_value) {
+    assert(go_value.type_ == TYPE_FLOAT);
+    return go_value.value.double_;
+}
+
+static bool get_go_value_bool(struct go_value go_value) {
+    assert(go_value.type_ == TYPE_BOOL);
+    return go_value.value.bool_;
+}
+
+static char *get_go_value_string(struct go_value go_value) {
+    assert(go_value.type_ == TYPE_STRING);
+    return go_value.value.string_;
 }
 
 // Gives a sample configuration for this plugin.

--- a/c_api.h
+++ b/c_api.h
@@ -60,3 +60,8 @@ extern void add_field(char *measurment,
         struct tag *tags, int tags_size,
         struct field *fields, int fields_size,
         int64_t unix_sec, int64_t unix_nsec);
+
+extern void add_gauge(char *measurment,
+        struct tag *tags, int tags_size,
+        struct field *fields, int fields_size,
+        int64_t unix_sec, int64_t unix_nsec);

--- a/c_api.h
+++ b/c_api.h
@@ -70,3 +70,8 @@ extern void add_counter(char *measurment,
         struct tag *tags, int tags_size,
         struct field *fields, int fields_size,
         int64_t unix_sec, int64_t unix_nsec);
+
+extern void add_summary(char *measurment,
+        struct tag *tags, int tags_size,
+        struct field *fields, int fields_size,
+        int64_t unix_sec, int64_t unix_nsec);

--- a/c_api.h
+++ b/c_api.h
@@ -1,0 +1,62 @@
+// Copyright 2019. Starry, Inc. All Rights Reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// Software written by Preston Carpenter <pcarpenter@starry.com>
+#include <assert.h>
+#include <stdint.h>
+
+struct go_value {
+    enum {
+        TYPE_INT
+    } type_;
+    union {
+        int int_;
+    } value;
+};
+
+struct tag {
+    char *key, *value;
+};
+
+struct field {
+    char *key;
+    struct go_value value;
+};
+
+static int get_go_value_int(struct go_value value) {
+    assert(value.type_ == TYPE_INT);
+    return value.value.int_;
+}
+
+// Gives a sample configuration for this plugin.
+char *sample_config(void);
+
+// Gives a description for what this plugin does.
+char *description(void);
+
+// Called by Go at a regular interval to collect data.
+void gather(void);
+
+extern void add_field(char *measurment,
+        struct tag *tags, int tags_size,
+        struct field *fields, int fields_size,
+        int64_t unix_sec, int64_t unix_nsec);

--- a/lib.go
+++ b/lib.go
@@ -151,3 +151,16 @@ func add_summary(measurement_ *C.char,
 		(*acc).AddSummary(measurement, fields, tags)
 	}
 }
+
+//export add_histogram
+func add_histogram(measurement_ *C.char,
+	tags_ *C.struct_tag, tags_size C.int,
+	fields_ *C.struct_field, fields_size C.int,
+	unix_sec, unix_nsec C.int64_t) {
+	measurement, fields, tags, t := add_generic(measurement_, tags_, tags_size, fields_, fields_size, unix_sec, unix_nsec)
+	if t != nil {
+		(*acc).AddHistogram(measurement, fields, tags, *t)
+	} else {
+		(*acc).AddHistogram(measurement, fields, tags)
+	}
+}

--- a/lib.go
+++ b/lib.go
@@ -138,3 +138,16 @@ func add_counter(measurement_ *C.char,
 		(*acc).AddCounter(measurement, fields, tags)
 	}
 }
+
+//export add_summary
+func add_summary(measurement_ *C.char,
+	tags_ *C.struct_tag, tags_size C.int,
+	fields_ *C.struct_field, fields_size C.int,
+	unix_sec, unix_nsec C.int64_t) {
+	measurement, fields, tags, t := add_generic(measurement_, tags_, tags_size, fields_, fields_size, unix_sec, unix_nsec)
+	if t != nil {
+		(*acc).AddSummary(measurement, fields, tags, *t)
+	} else {
+		(*acc).AddSummary(measurement, fields, tags)
+	}
+}

--- a/lib.go
+++ b/lib.go
@@ -32,6 +32,7 @@ import "C"
 
 import (
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
 	"log"
 	"time"
 	"unsafe"
@@ -41,6 +42,10 @@ type RustPlugin struct{}
 
 var Plugin telegraf.Input = &RustPlugin{}
 var acc *telegraf.Accumulator = nil
+
+func init() {
+	inputs.Add("rust_plugin", func() telegraf.Input { return &RustPlugin{} })
+}
 
 func (plugin *RustPlugin) SampleConfig() string {
 	return C.GoString(C.sample_config())

--- a/lib.go
+++ b/lib.go
@@ -1,0 +1,96 @@
+// Copyright 2019. Starry, Inc. All Rights Reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// Software written by Preston Carpenter <pcarpenter@starry.com>
+package main
+
+/*
+#cgo CFLAGS: -g -Wall -Wpedantic -Werror -Wno-unused-function -Wno-unused-variable
+#cgo LDFLAGS: -L. -l:plugin.a -ldl
+#include "c_api.h"
+*/
+import "C"
+
+import (
+	"github.com/influxdata/telegraf"
+	"log"
+	"time"
+	"unsafe"
+)
+
+type RustPlugin struct{}
+
+var Plugin telegraf.Input = &RustPlugin{}
+var acc *telegraf.Accumulator = nil
+
+func (plugin *RustPlugin) SampleConfig() string {
+	return C.GoString(C.sample_config())
+}
+
+func (plugin *RustPlugin) Description() string {
+	return C.GoString(C.description())
+}
+
+func (plugin *RustPlugin) Gather(acc_ telegraf.Accumulator) error {
+	acc = &acc_
+	C.gather()
+	acc = nil
+	return nil
+}
+
+//export add_field
+func add_field(measurement_ *C.char,
+	tags_ *C.struct_tag, tags_size C.int,
+	fields_ *C.struct_field, fields_size C.int,
+	unix_sec, unix_nsec C.int64_t) {
+	if acc == nil {
+		log.Fatal("No accumulator was active, only call this from Gather")
+	}
+	measurement := C.GoString(measurement_)
+	tag_list := (*[1 << 32]C.struct_tag)(unsafe.Pointer(tags_))[:tags_size]
+	field_list := (*[1 << 32]C.struct_field)(unsafe.Pointer(fields_))[:fields_size]
+
+	tags := make(map[string]string)
+	for _, tag := range tag_list {
+		key := C.GoString(tag.key)
+		value := C.GoString(tag.value)
+		tags[key] = value
+	}
+
+	fields := make(map[string]interface{})
+	for _, field := range field_list {
+		key := C.GoString(field.key)
+		var value interface{}
+		switch field.value.type_ {
+		case C.TYPE_INT:
+			value = int(C.get_go_value_int(field.value))
+		}
+		fields[key] = value
+	}
+
+	if unix_sec == 0 && unix_nsec == 0 {
+		(*acc).AddFields(measurement, fields, tags)
+	} else {
+		timestamp := time.Unix(int64(unix_sec), int64(unix_nsec))
+		(*acc).AddFields(measurement, fields, tags, timestamp)
+	}
+}

--- a/lib.go
+++ b/lib.go
@@ -85,11 +85,7 @@ func add_generic(measurement_ *C.char,
 	fields = make(map[string]interface{})
 	for _, field := range field_list {
 		key := C.GoString(field.key)
-		var value interface{}
-		switch field.value.type_ {
-		case C.TYPE_INT:
-			value = int(C.get_go_value_int(field.value))
-		}
+		value := convert_to_go_value(field.value)
 		fields[key] = value
 	}
 	timestamp = nil
@@ -163,4 +159,20 @@ func add_histogram(measurement_ *C.char,
 	} else {
 		(*acc).AddHistogram(measurement, fields, tags)
 	}
+}
+
+func convert_to_go_value(c_value C.struct_go_value) (go_value interface{}) {
+	switch c_value.type_ {
+	case C.TYPE_INT:
+		go_value = int64(C.get_go_value_int(c_value))
+	case C.TYPE_UINT:
+		go_value = uint64(C.get_go_value_uint(c_value))
+	case C.TYPE_FLOAT:
+		go_value = float64(C.get_go_value_double(c_value))
+	case C.TYPE_BOOL:
+		go_value = bool(C.get_go_value_bool(c_value))
+	case C.TYPE_STRING:
+		go_value = C.GoString(C.get_go_value_string(c_value))
+	}
+	return
 }

--- a/lib.go
+++ b/lib.go
@@ -100,6 +100,19 @@ func add_generic(measurement_ *C.char,
 	return
 }
 
+//export add_field
+func add_field(measurement_ *C.char,
+	tags_ *C.struct_tag, tags_size C.int,
+	fields_ *C.struct_field, fields_size C.int,
+	unix_sec, unix_nsec C.int64_t) {
+	measurement, fields, tags, t := add_generic(measurement_, tags_, tags_size, fields_, fields_size, unix_sec, unix_nsec)
+	if t != nil {
+		(*acc).AddFields(measurement, fields, tags, *t)
+	} else {
+		(*acc).AddFields(measurement, fields, tags)
+	}
+}
+
 //export add_gauge
 func add_gauge(measurement_ *C.char,
 	tags_ *C.struct_tag, tags_size C.int,
@@ -113,15 +126,15 @@ func add_gauge(measurement_ *C.char,
 	}
 }
 
-//export add_field
-func add_field(measurement_ *C.char,
+//export add_counter
+func add_counter(measurement_ *C.char,
 	tags_ *C.struct_tag, tags_size C.int,
 	fields_ *C.struct_field, fields_size C.int,
 	unix_sec, unix_nsec C.int64_t) {
 	measurement, fields, tags, t := add_generic(measurement_, tags_, tags_size, fields_, fields_size, unix_sec, unix_nsec)
 	if t != nil {
-		(*acc).AddFields(measurement, fields, tags, *t)
+		(*acc).AddCounter(measurement, fields, tags, *t)
 	} else {
-		(*acc).AddFields(measurement, fields, tags)
+		(*acc).AddCounter(measurement, fields, tags)
 	}
 }


### PR DESCRIPTION
This code exports the Go plugin interface implemented in [this telegraf PR](https://github.com/influxdata/telegraf/pull/6024) as a C interface so that other languages can consume it.

CC @agreen17 and @dbutler-starry for review of the Go code.